### PR TITLE
More kernels + package extensions

### DIFF
--- a/archlinux-update-modules
+++ b/archlinux-update-modules
@@ -70,13 +70,20 @@ fi
 
 architecture=$(uname -m)
 kernel_release=$(uname -r)
-#kernel_release=4.14.31-1-lts # only for testing
+# kernel_release=4.14.31-1-lts # only for testing
+# kernel_release=5.1.9-arch1-1-ARCH  # only for testing
+# kerenl_release=5.1.10-1-ck-haswell # only for testing
 
-pkg_name=linux
-if [[ "$kernel_release" == *-lts ]] ; then
-    pkg_name=linux-lts
+
+pkg_ver=$(echo "${kernel_release}" | grep -Po ".+-\d+") # split version number from name
+pkg_suffix=${kernel_release/${pkg_ver}/}
+
+if [ "$pkg_suffix" == "-ARCH" ]; then
+    pkg_name="linux"
+else
+    pkg_name="linux${pkg_suffix}"
 fi
-pkg_ver="${kernel_release%-*}" # remove the -ARCH
+
 pkg_ver="${pkg_ver/-arch/.arch}" # it's .arch in the package version but -arch in the uname output
 
 # find a pkg file with the modules for the running system

--- a/archlinux-update-modules
+++ b/archlinux-update-modules
@@ -80,8 +80,7 @@ pkg_ver="${kernel_release%-*}" # remove the -ARCH
 pkg_ver="${pkg_ver/-arch/.arch}" # it's .arch in the package version but -arch in the uname output
 
 # find a pkg file with the modules for the running system
-pkgfile=/var/cache/pacman/pkg/
-pkgfile+="$pkg_name"-"${pkg_ver}"-"$architecture".pkg.tar.xz
+pkgfile=(/var/cache/pacman/pkg/"${pkg_name}"-"${pkg_ver}"-"${architecture}".pkg.tar*) # use array to expand glob
 running_moddir="/usr/lib/modules/${kernel_release}"
 
 # == restore module directory for current path ==
@@ -89,12 +88,12 @@ running_moddir="/usr/lib/modules/${kernel_release}"
 if [[ ! -d "$running_moddir" ]] ; then
     msg "The module directory $running_moddir"
     msg "for the running kernel ${kernel_release} does not exist."
-    if [[ ! -e "${pkgfile}" ]] ; then
-        msg "But the package does not exist: ${pkgfile}"
+    if [[ ! -e "${pkgfile[0]}" ]] ; then
+        msg "But the package does not exist: ${pkgfile[0]}"
     else
         # the moddir path needs to be relative, so no leading /
-        ask_command "Do you want to restore it from ${pkgfile}?" \
-            sudo tar -C / -xvf "${pkgfile}" "${running_moddir#/}"
+        ask_command "Do you want to restore it from ${pkgfile[0]}?" \
+            sudo tar -C / -xvf "${pkgfile[0]}" "${running_moddir#/}"
     fi
 else
     msg "The running kernel ${kernel_release} already has a module directory $running_moddir, nothing to do"


### PR DESCRIPTION
Two changes that I needed to get this working on my system:

1) The package isn't guaranteed to be .pkg.tar.xz, so use a wildcard to find any extension.
2) Change package name logic to detect more kernels. I've tested this on linux, linux-lts, and linux-ck, but it should support most if they have consistent names.